### PR TITLE
Fix freeze on subprocess communicate

### DIFF
--- a/tools/butano/butano_fonts_tool.py
+++ b/tools/butano/butano_fonts_tool.py
@@ -53,7 +53,7 @@ def process_texts_files(texts_file_paths, characters_file_path):
     for texts_file_path in texts_file_paths:
         texts_file_ext = os.path.splitext(texts_file_path.lower())[1]
         if texts_file_ext in ('.c', '.cpp', '.cc', '.cxx', '.c++', '.h', '.hpp', '.hh', '.hxx', '.h++', '.s', '.inc', '.asm'):
-            text = subprocess.check_output([os.environ['DEVKITARM'] + '/bin/arm-none-eabi-cpp', '-fpreprocessed', texts_file_path],shell=True).decode('utf-8')
+            text = subprocess.check_output([os.environ['DEVKITARM'] + '/bin/arm-none-eabi-cpp', '-fpreprocessed', texts_file_path]).decode('utf-8')
             for char in text:
                 unique_characters.add(char)
             continue


### PR DESCRIPTION
## System Info
Ubuntu 20.04
Python 3.8.10
Pillow 9.2.0
devkitARM-r58-2
Butano 12.0.0

## Behavior

On the system above, if I type `make` on the example, it hangs forever on this line.

https://github.com/laqieer/gba-free-fonts/blob/1074470a77e34064d263e6076cad728da1429801/tools/butano/butano_fonts_tool.py#L56

```bash
~/gba-free-fonts/examples/butano$ make
^CTraceback (most recent call last):
  File "../../tools/butano/butano_fonts_tool.py", line 277, in <module>
    process_fonts(args.fonts, args.build, args.texts)
  File "../../tools/butano/butano_fonts_tool.py", line 252, in process_fonts
    process_texts_files(texts_file_paths, characters_file_path)
  File "../../tools/butano/butano_fonts_tool.py", line 56, in process_texts_files
    text = subprocess.check_output([os.environ['DEVKITARM'] + '/bin/arm-none-eabi-cpp', '-fpreprocessed', texts_file_path],shell=True).decode('utf-8')
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 495, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1015, in communicate
    stdout = self.stdout.read()
KeyboardInterrupt
make: *** [/home/ubuntu/butano/butano/butano.mak:167: all] Interrupt
```


## Fix

Removing `shell=True` from this line fixes this issue (at least for me).
[Related article](https://splunktool.com/python-subprocess-communicate-freezes)

```bash
~/gba-free-fonts/examples/butano$ make
hanamin.fnt
unifont.fnt
...
```