### PR TITLE
Add wonderful toolchain support

### DIFF
--- a/tools/butano/butano_fonts_tool.py
+++ b/tools/butano/butano_fonts_tool.py
@@ -53,7 +53,12 @@ def process_texts_files(texts_file_paths, characters_file_path):
     for texts_file_path in texts_file_paths:
         texts_file_ext = os.path.splitext(texts_file_path.lower())[1]
         if texts_file_ext in ('.c', '.cpp', '.cc', '.cxx', '.c++', '.h', '.hpp', '.hh', '.hxx', '.h++', '.s', '.inc', '.asm'):
-            text = subprocess.check_output([os.environ['DEVKITARM'] + '/bin/arm-none-eabi-cpp', '-fpreprocessed', texts_file_path]).decode('utf-8')
+            if os.environ.get('DEVKITARM'):
+                text = subprocess.check_output([os.environ['DEVKITARM'] + '/bin/arm-none-eabi-cpp', '-fpreprocessed', texts_file_path]).decode('utf-8')
+            elif os.environ.get('WONDERFUL_TOOLCHAIN'):
+                text = subprocess.check_output([os.environ['WONDERFUL_TOOLCHAIN'] + '/toolchain/gcc-arm-none-eabi/bin/arm-none-eabi-cpp', '-fpreprocessed', texts_file_path]).decode('utf-8')
+            else:
+                raise Exception('DEVKITARM and WONDERFUL_TOOLCHAIN not found')
             for char in text:
                 unique_characters.add(char)
             continue


### PR DESCRIPTION
This commit adds wonderful toolchain support for `butano_fonts_tool.py`.

To test it, see [Getting started with Wonderful Toolchain (Butano Docs)](https://gvaliente.github.io/butano/getting_started_wt.html)